### PR TITLE
Add branch for v8.2 and update to v8.3

### DIFF
--- a/grass_addons.sh
+++ b/grass_addons.sh
@@ -73,7 +73,8 @@ if test -z $1 ; then
     compile 786
     compile 80
     compile 800
-    compile 81
+    compile 82
+    compile 83
 else
     compile $1
 fi


### PR DESCRIPTION
- There is a new branch for v8.2 (releasebranch_8_2).
- The main branch was re-labeled to v8.3 (8.3dev/8.3.dev).

I must say I'm only following the release procedure which says to update it here.